### PR TITLE
Add Google Fonts and styling for body and headings

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Contact - Renaissance Faire</title>
   <link rel="stylesheet" href="css/styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Pirata+One&family=Uncial+Antiqua&display=swap" rel="stylesheet">
+
+  <title>Contact - Renaissance Faire</title>
 </head>
 <body>
   <div data-include="components/header.html"></div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,4 +1,12 @@
-
+body {
+    font-family: 'Open Sans', sans-serif;
+  }
+  
+  /* Ye Olde style fonts */
+  h1, h2, h3 {
+    font-family: 'Pirata One', 'Uncial Antiqua', serif;
+  }
+  
 /* Contact Form Modal */
 #modal {
     position: fixed;

--- a/events.html
+++ b/events.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Events - Renaissance Faire</title>
   <link rel="stylesheet" href="css/styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Pirata+One&family=Uncial+Antiqua&display=swap" rel="stylesheet">
+
+  <title>Events - Renaissance Faire</title>
 </head>
 <body>
   <div data-include="components/header.html"></div>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="css/styles.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Pirata+One&family=Uncial+Antiqua&display=swap" rel="stylesheet">
+
     <title>Renaissance Faire</title>
 </head>
 <body>

--- a/location.html
+++ b/location.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Location - Renaissance Faire</title>
   <link rel="stylesheet" href="css/styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Pirata+One&family=Uncial+Antiqua&display=swap" rel="stylesheet">
+
+  <title>Location - Renaissance Faire</title>
 </head>
 <body>
   <div data-include="components/header.html"></div>

--- a/menu.html
+++ b/menu.html
@@ -3,8 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Menu - Renaissance Faire</title>
   <link rel="stylesheet" href="css/styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Pirata+One&family=Uncial+Antiqua&display=swap" rel="stylesheet">
+
+  <title>Menu - Renaissance Faire</title>
 </head>
 <body>
   <div data-include="components/header.html"></div>


### PR DESCRIPTION
This PR adds site-wide typography to support a Renaissance Faire aesthetic, using Google Fonts and CSS.

### ✅ Summary of Changes
- Added Google Fonts link (`Open Sans`, `Pirata One`, `Uncial Antiqua`) in the `<head>` section of all main HTML pages
- Updated `styles.css`:
  - Set `Open Sans` as the default font for body text
  - Applied `Pirata One` and `Uncial Antiqua` to all headings (h1–h3)
- Ensured consistent font styling across all site pages

### 💡 Why These Fonts?
- `Open Sans`: Clean and readable for modern accessibility standards
- `Pirata One` & `Uncial Antiqua`: Thematic, old english/medieval style fonts to match the Renaissance Faire setting

### 🔍 How to Review
- Open any page (e.g., `index.html`, `contact.html`) in Live Server
- Verify readable body text and decorative heading fonts
- Confirm visual consistency and legibility

---
Future planned updates: background textures, navigation bar styling, and layout enhancements.
