### PR TITLE
Fix missing modal caused by missing script src

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -51,8 +51,9 @@
 
   <div data-include="components/footer.html"></div>
 
-  <!-- JS (header, footer, hamburger menu) -->
+  <!-- JS (header, footer, hamburger menu, and contact modal) -->
   <script src="js/includes.js"></script>
   <script src="js/menu-toggle.js"></script>
+  <script src="js/modal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #14

This PR corrects the modal display issue. The script source was missing at the bottom of the page.

Edit: Fixes 14 not 12
